### PR TITLE
Access API on the same host that served the web

### DIFF
--- a/src/helpers/baseUrlAPI.js
+++ b/src/helpers/baseUrlAPI.js
@@ -1,3 +1,6 @@
-const hosting = 'http://localhost:8080';
+const {protocol, hostname} = window?.location ?? {};
+const hosting = !!protocol && !!hostname
+    ? `${protocol}//${hostname}:8080`
+    : 'http://localhost:8080';
 
 export default hosting;


### PR DESCRIPTION
Update API base URL to point to the same hostname which served the static web page. Leave the old behavior for electron version. This enables hosting the site from a server other than localhost.